### PR TITLE
Replace the array_merge with spread array operator

### DIFF
--- a/src/MichaelPetri/GenericList/ImmutableList.php
+++ b/src/MichaelPetri/GenericList/ImmutableList.php
@@ -95,10 +95,7 @@ final class ImmutableList
      */
     public function with(mixed $item): self
     {
-        return self::of(...\array_merge(
-            $this->toArray(),
-            [$item]
-        ));
+        return self::of(...[...$this->toArray(), $item]);
     }
 
     /** @psalm-return self<T> */


### PR DESCRIPTION
# Changed log

- According to the [reference](https://wiki.php.net/rfc/spread_operator_for_array), it's great to use the spread array operator to replace the `array_merge` function.
- There're two reasons about using the spread array operator:
  - Spread operator should have a better performance than array_merge and compile time optimization can be performant for constant arrays.
  - `array_merge` only supports array, while the spread operator also supports objects implementing `Traversable`.